### PR TITLE
Simplify setVolume function by using setVolume (group_set_volume) tha…

### DIFF
--- a/lib/OD11.js
+++ b/lib/OD11.js
@@ -103,14 +103,9 @@ class OD11 extends EventEmitter {
 
 	//val between 0 and 100
 	setVolume(absoluteValue) {
-		assert(this.maxVolume && this.volume)
-
-		let goalValue = absoluteValue / 100 * this.maxVolume
-			let valueDifference = goalValue - this.volume
-			this.sendAction(OD11Action.changeVolume(valueDifference))
-		
+		this.sendAction(OD11Action.setVolume(absoluteValue))
 	}
-	
+
 	schedulePing() {
 		setTimeout(function(){
 			this.sendAction(OD11Action.ping)

--- a/lib/OD11Action.js
+++ b/lib/OD11Action.js
@@ -36,6 +36,13 @@ class OD11Action {
 		}
 	}
 
+	static setVolume(volume) {
+		return {
+			"vol": volume,
+			"action": "group_set_volume"
+		}
+	}
+
 	static seekTrack(time) {
 		assert(time >= 0 && time <= 1)
 		return {


### PR DESCRIPTION
…t takes absolute volume level as argument.

Please note that this is untested. I haven't had time to set up a test environment properly (to be honest, I've never used node).
